### PR TITLE
Remove `chai` deprecation warnings when running tests

### DIFF
--- a/lib/poparser.js
+++ b/lib/poparser.js
@@ -97,15 +97,15 @@ Parser.prototype.symbols = {
  *
  * @return {Object} Parsed tokens
  */
-Parser.prototype._lexer = function() {
+Parser.prototype._lexer = function(chunk, lex) {
     var chr,
         escaped = false,
-        lex = [],
+        lex = lex || [],
         node,
         state = this.states.none;
 
-    for (var i = 0, len = this._fileContents.length; i < len; i++) {
-        chr = this._fileContents.charAt(i);
+    for (var i = 0, len = chunk.length; i < len; i++) {
+        chr = chunk.charAt(i);
         switch (state) {
             case this.states.none:
                 if (chr.match(this.symbols.quotes)) {
@@ -380,7 +380,7 @@ Parser.prototype._normalize = function(lex) {
  * @return {Object} Translation table
  */
 Parser.prototype.parse = function() {
-    var lex = this._lexer();
+    var lex = this._lexer(this._fileContents);
 
     lex = this._joinStringValues(lex);
     this._parseComments(lex);

--- a/test/folder-test.js
+++ b/test/folder-test.js
@@ -4,7 +4,7 @@ var chai = require('chai');
 var sharedFuncs = require('../lib/shared');
 
 var expect = chai.expect;
-chai.Assertion.includeStack = true;
+chai.config.includeStack = true;
 
 describe('Folding tests', function() {
 

--- a/test/mo-compiler-test.js
+++ b/test/mo-compiler-test.js
@@ -5,7 +5,7 @@ var gettextParser = require('..');
 var fs = require('fs');
 
 var expect = chai.expect;
-chai.Assertion.includeStack = true;
+chai.config.includeStack = true;
 
 describe('MO Compiler', function() {
 

--- a/test/mo-parser-test.js
+++ b/test/mo-parser-test.js
@@ -5,7 +5,7 @@ var gettextParser = require('..');
 var fs = require('fs');
 
 var expect = chai.expect;
-chai.Assertion.includeStack = true;
+chai.config.includeStack = true;
 
 describe('MO Parser', function() {
 

--- a/test/po-compiler-test.js
+++ b/test/po-compiler-test.js
@@ -5,7 +5,7 @@ var gettextParser = require('..');
 var fs = require('fs');
 
 var expect = chai.expect;
-chai.Assertion.includeStack = true;
+chai.config.includeStack = true;
 
 describe('PO Compiler', function() {
 

--- a/test/po-parser-test.js
+++ b/test/po-parser-test.js
@@ -5,7 +5,7 @@ var gettextParser = require('..');
 var fs = require('fs');
 
 var expect = chai.expect;
-chai.Assertion.includeStack = true;
+chai.config.includeStack = true;
 
 describe('PO Parser', function() {
 


### PR DESCRIPTION
This removes the warnings:

```
npm test

> gettext-parser@1.0.0 test /Users/arnaud/projects/gettext-parser
> grunt

Running "jshint:all" (jshint) task
>> 6 files lint free.

Running "mochaTest:all" (mochaTest) task
Assertion.includeStack is deprecated, use chai.config.includeStack instead.
Assertion.includeStack is deprecated, use chai.config.includeStack instead.
Assertion.includeStack is deprecated, use chai.config.includeStack instead.
Assertion.includeStack is deprecated, use chai.config.includeStack instead.
Assertion.includeStack is deprecated, use chai.config.includeStack instead.
```