### PR TITLE
Fixed translation object json structure in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,18 +178,17 @@ Example
         "msgid": "",
         "msgstr": ["Content-Type: text/plain; charset=iso-8859-1\n..."]
       }
-    }
-  },
-
-  "another context": {
-    "%s example": {
-      "msgctx": "another context",
-      "msgid": "%s example",
-      "msgid_plural": "%s examples",
-      "msgstr": ["% näide", "%s näidet"],
-      "comments": {
-        "translator": "This is regular comment",
-        "reference": "/path/to/file:123"
+    },
+    "another context": {
+      "%s example": {
+        "msgctx": "another context",
+        "msgid": "%s example",
+        "msgid_plural": "%s examples",
+        "msgstr": ["% näide", "%s näidet"],
+        "comments": {
+          "translator": "This is regular comment",
+          "reference": "/path/to/file:123"
+        }
       }
     }
   }


### PR DESCRIPTION
From what I understand (and reading the code at https://github.com/andris9/gettext-parser/blob/master/lib/pocompiler.js#L204) additional contexts should be specified under `obj["translations"]["contextname"]` and not `obj["contextname"]`